### PR TITLE
Save recording after the call (low-quality)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,16 +3,14 @@
 {
 	"name": "Python 3",
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/azure/azure-dev/azd:0": {},
-    	"ghcr.io/va-h/devcontainers-features/uv:1": {}
+		"ghcr.io/va-h/devcontainers-features/uv:1": {}
 	},
-
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
@@ -22,16 +20,25 @@
 				"ms-python.python",
 				"ms-python.debugpy",
 				"ms-azuretools.vscode-docker"
-			]
+			],
+			"settings": {
+				"[python]": {
+					"editor.formatOnSave": true,
+					"editor.defaultFormatter": "charliermarsh.ruff",
+					"editor.codeActionsOnSave": {
+						"source.fixAll": "explicit",
+						"source.organizeImports": "explicit"
+					}
+				}
+			}
 		}
 	},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
+	"forwardPorts": [
+		5000
+	],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "cd server/python && uv sync && uv run pre-commit install"
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/server/python/app/audio.py
+++ b/server/python/app/audio.py
@@ -3,6 +3,8 @@
 import numpy as np
 import wave
 
+from .enums import MediaFormat
+
 
 def ulaw2linear(ulaw):
     """Convert u-Law encoded bytes to Linear-16 PCM values"""
@@ -15,11 +17,18 @@ def ulaw2linear(ulaw):
     linear = (mantissa << 4) + 0x08
     linear = linear << exponent
     linear = np.where(sign != 0, linear - 0x84, 0x84 - linear)
+
     return linear
 
 
-def save_to_wav(filename, audio_data, channels, sample_width, frame_rate):
+def save_to_wav(filename, format, audio_data, channels, sample_width, frame_rate):
     """Save audio data to a WAV file."""
+
+    # Convert the linear PCMU data to bytes
+    if format == MediaFormat.PCMU:
+        linear_pcm = ulaw2linear(audio_data)
+        audio_data = linear_pcm.tobytes()
+
     with wave.open(filename, "wb") as wav_file:
         wav_file.setnchannels(channels)
         wav_file.setsampwidth(sample_width)

--- a/server/python/app/audio.py
+++ b/server/python/app/audio.py
@@ -1,0 +1,27 @@
+"""Audio utilities for the server."""
+
+import numpy as np
+import wave
+
+
+def ulaw2linear(ulaw):
+    """Convert u-Law encoded bytes to Linear-16 PCM values"""
+    ulaw = np.frombuffer(ulaw, dtype=np.uint8)
+    ulaw = ulaw.astype(np.int16)
+    ulaw = ulaw ^ 0xFF
+    sign = ulaw & 0x80
+    exponent = (ulaw & 0x70) >> 4
+    mantissa = ulaw & 0x0F
+    linear = (mantissa << 4) + 0x08
+    linear = linear << exponent
+    linear = np.where(sign != 0, linear - 0x84, 0x84 - linear)
+    return linear
+
+
+def save_to_wav(filename, audio_data, channels, sample_width, frame_rate):
+    """Save audio data to a WAV file."""
+    with wave.open(filename, "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(sample_width)
+        wav_file.setframerate(frame_rate)
+        wav_file.writeframes(audio_data)

--- a/server/python/app/enums.py
+++ b/server/python/app/enums.py
@@ -43,3 +43,9 @@ class DisconnectReason(StrEnum):
     COMPLETED = "completed"
     ERROR = "error"
     UNAUTHORIZED = "unauthorized"
+
+
+@unique
+class MediaFormat(StrEnum):
+    PCMU = "PCMU"
+    L16 = "L16"

--- a/server/python/app/models.py
+++ b/server/python/app/models.py
@@ -36,6 +36,7 @@ class ClientSession:
     last_rtt: int | None = None
     media: dict | None = None
     audio_buffer: bytearray | None = None
+    duration: float = 0
 
 
 @dataclass(kw_only=True)

--- a/server/python/app/models.py
+++ b/server/python/app/models.py
@@ -44,4 +44,3 @@ class HealthCheckResponse:
 
     status: str
     connected_clients: int
-    sessions: dict[str, ClientSession]

--- a/server/python/app/models.py
+++ b/server/python/app/models.py
@@ -35,6 +35,7 @@ class ClientSession:
     rtt: list[int] = field(default_factory=list)
     last_rtt: int | None = None
     media: dict | None = None
+    audio_buffer: Any | None = None
 
 
 @dataclass(kw_only=True)

--- a/server/python/app/models.py
+++ b/server/python/app/models.py
@@ -36,7 +36,6 @@ class ClientSession:
     last_rtt: int | None = None
     media: dict | None = None
     audio_buffer: bytearray | None = None
-    duration: float = 0
 
 
 @dataclass(kw_only=True)

--- a/server/python/app/models.py
+++ b/server/python/app/models.py
@@ -35,7 +35,7 @@ class ClientSession:
     rtt: list[int] = field(default_factory=list)
     last_rtt: int | None = None
     media: dict | None = None
-    audio_buffer: Any | None = None
+    audio_buffer: bytearray | None = None
 
 
 @dataclass(kw_only=True)

--- a/server/python/app/websocket_server.py
+++ b/server/python/app/websocket_server.py
@@ -95,8 +95,7 @@ class WebsocketServer:
                 await self.handle_bytes(data, session_id)
             else:
                 self.logger.debug(
-                    f"[{session_id}] Received unknown data type: {type(data)}: {
-                        data}"
+                    f"[{session_id}] Received unknown data type: {type(data)}: {data}"
                 )
 
     async def disconnect(self, reason: DisconnectReason, message: str, code: int):
@@ -141,8 +140,7 @@ class WebsocketServer:
         if message["seq"] != self.clients[session_id].client_seq + 1:
             self.disconnect(
                 reason=DisconnectReason.ERROR,
-                message=f"Sequence number mismatch: received {
-                    message['seq']}, expected {self.clients[session_id].client_seq + 1}",
+                message=f"Sequence number mismatch: received {message['seq']}, expected {self.clients[session_id].client_seq + 1}",
                 code=3000,
             )
 
@@ -160,8 +158,7 @@ class WebsocketServer:
                 await self.handle_close_message(message)
             case _:
                 self.logger.info(
-                    f"[{session_id}] Unknown message type: {
-                        message['type']} : {message}"
+                    f"[{session_id}] Unknown message type: {message['type']} : {message}"
                 )
 
     async def handle_ping_message(self, message: dict):
@@ -267,8 +264,7 @@ class WebsocketServer:
             )
 
             self.logger.info(
-                f"[{session_id}] Audio data saved to {filename} ({media["type"]}, format {
-                    media["format"]}, rate {media["rate"]}, channels {len(media["channels"])}"
+                f"[{session_id}] Audio data saved to {filename} ({media["type"]}, format {media["format"]}, rate {media["rate"]}, channels {len(media["channels"])}"
             )
 
             await self.send_message(

--- a/server/python/app/websocket_server.py
+++ b/server/python/app/websocket_server.py
@@ -259,10 +259,6 @@ class WebsocketServer:
         if parameters["reason"] == CloseReason.END:
             # Save the audio data to a WAV file
             media = self.clients[session_id].media
-            self.logger.info(
-                f"[{session_id}] Saving {media["type"]}, format {media["format"]}, rate {media["rate"]}, channels {len(media["channels"])}"
-            )
-
             timestamp = int(datetime.now().timestamp())
             filename = f"{session_id}_{timestamp}.wav"
             save_to_wav(
@@ -273,7 +269,9 @@ class WebsocketServer:
                 frame_rate=media["rate"],
             )
 
-            self.logger.info(f"[{session_id}] Audio data saved to {filename}")
+            self.logger.info(
+                f"[{session_id}] Audio data saved to {filename} ({media["type"]}, format {media["format"]}, rate {media["rate"]}, channels {len(media["channels"])}"
+            )
 
             await self.send_message(
                 type=ServerMessageType.CLOSED, client_message=message
@@ -299,10 +297,6 @@ class WebsocketServer:
         self.logger.info(
             f"[{session_id}] type {media["type"]}, format {media["format"]}, rate {media["rate"]}, channels {len(media["channels"])}"
         )
-
-        # Calculate the duration of the audio data
-        # audio_duration = (len(data) * 8) / (media["rate"] * len(media["channels"]))
-        # self.logger.info(f"[{session_id}] Audio duration: {audio_duration} seconds")
 
         # Initialize or append to the audio buffer for the session
         if self.clients[session_id].audio_buffer is None:

--- a/server/python/app/websocket_server.py
+++ b/server/python/app/websocket_server.py
@@ -195,6 +195,7 @@ class WebsocketServer:
         dnis = parameters["participant"]["dnis"]
         session_id = message["id"]
         media = parameters["media"]
+        position = message["position"]
 
         if conversation_id == "00000000-0000-0000-0000-000000000000":
             # TODO implement connection probe handling
@@ -204,7 +205,7 @@ class WebsocketServer:
             )
 
         self.logger.info(
-            f"[{session_id}] Session opened with conversation ID: {conversation_id}, ANI Name: {ani_name}, DNIS: {dnis}"
+            f"[{session_id}] Session opened with conversation ID: {conversation_id}, ANI Name: {ani_name}, DNIS: {dnis}, Position: {position}"
         )
         self.logger.info(f"[{session_id}] Available media: {media}")
 
@@ -277,7 +278,7 @@ class WebsocketServer:
 
     async def handle_bytes(self, data: bytes, session_id: str):
         """
-        Handles audio stream in u-Law ("PCMU") and converts it to WAV format
+        Handles audio stream in u-Law ("PCMU")
 
         The audio in the frames for PCMU are headerless and the samples of two-channel streams are interleaved. For example, a 100ms audio frame in the format negotiated in the above example (PCMU, two channels, 8000Hz sample rate) would comprise 1600 bytes and have the following layout:
         The number of samples per frame is variable and is up to the client. There is a tradeoff between higher latency (larger frames) and higher overhead (smaller frames). The client will guarantee that frames only contain whole samples for all channels (i.e. the bytes of individual samples will not be split across frames). The server must not make any assumptions about audio frame sizes and maintain a timeline of the audio stream by counting the samples.

--- a/server/python/app/websocket_server.py
+++ b/server/python/app/websocket_server.py
@@ -212,24 +212,17 @@ class WebsocketServer:
         self.clients[session_id].dnis = dnis
         self.clients[session_id].conversation_id = conversation_id
 
-        # Filter available media for channels with length of 2 and containing "internal" and "external" (stereo)
-        stereo_media = [
-            m
-            for m in media
-            if len(m["channels"]) == 2
-            and "internal" in m["channels"]
-            and "external" in m["channels"]
-        ]
+        # Select stereo media if available, otherwise fallback to the first media format
+        selected_media = next(
+            (
+                m
+                for m in media
+                if len(m["channels"]) == 2
+                and {"internal", "external"}.issubset(m["channels"])
+            ),
+            media[0],
+        )
 
-        if stereo_media:
-            selected_media = stereo_media[0]
-        else:
-            self.logger.warning(
-                f"[{session_id}] No stereo media found, falling back to first available media format."
-            )
-            selected_media = media[0]
-
-        # Open stream with selected media format
         await self.send_message(
             type=ServerMessageType.OPENED,
             client_message=message,

--- a/server/python/app/websocket_server.py
+++ b/server/python/app/websocket_server.py
@@ -35,13 +35,9 @@ class WebsocketServer:
 
     async def health_check(self):
         """Health check endpoint"""
-        # TODO this approach won't work with multiple workers (each worker will have its own memory storage)
+        # TODO this won't show the right amount of connected clients with multiple workers (each worker will have its own memory storage)
         return dataclasses.asdict(
-            HealthCheckResponse(
-                status="online",
-                connected_clients=len(self.clients),
-                sessions=self.clients,
-            )
+            HealthCheckResponse(status="online", connected_clients=len(self.clients))
         )
 
     async def ws(self):

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -4,6 +4,12 @@ import logging
 
 from app.websocket_server import WebsocketServer
 
+# Set logging level based on environment variables
+if os.getenv("RUNNING_IN_PRODUCTION") and os.getenv("DEBUG_MODE") != "true":
+    logging.basicConfig(level=logging.WARNING)
+else:
+    logging.basicConfig(level=logging.INFO)
+
 # Run development server when running this script directly.
 # For production it is recommended that Quart will be run using Hypercorn or an alternative ASGI server.
 if __name__ == "__main__":
@@ -13,9 +19,3 @@ if __name__ == "__main__":
 else:
     server = WebsocketServer()
     app = server.app
-
-# Set logging level based on environment variables
-if os.getenv("RUNNING_IN_PRODUCTION") and os.getenv("DEBUG_MODE") != "true":
-    logging.basicConfig(level=logging.WARNING)
-else:
-    logging.basicConfig(level=logging.INFO)

--- a/server/python/tests/test_websocket_server.py
+++ b/server/python/tests/test_websocket_server.py
@@ -24,10 +24,7 @@ async def test_health_check(app):
     response = await app.get("/")
 
     assert response.status_code == 200
-    assert (
-        await response.data
-        == b'{"connected_clients":0,"sessions":{},"status":"online"}\n'
-    )
+    assert await response.data == b'{"connected_clients":0,"status":"online"}\n'
 
 
 @pytest.mark.asyncio
@@ -41,7 +38,6 @@ async def test_health_check_valid_json(app):
     assert data is not None
     assert data["status"] == "online"
     assert data["connected_clients"] == 0
-    assert data["sessions"] == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Initial attempt to save audio after a call. For now this is in lower quality than the initial call (not sure why).

This pull request introduces several enhancements to the audio handling and logging functionality in the server. The most important changes include adding new audio utilities, updating the WebSocket server to handle audio data, and refining logging configurations.

### Audio Handling Enhancements:
* [`server/python/app/audio.py`](diffhunk://#diff-f6d1af257eb3fb7cacd9d20a517fb12b831d695ce3336c4129c078d9f3fb70bcR1-R36): Added new audio utilities for converting u-Law encoded bytes to Linear-16 PCM values and saving audio data to WAV files.
* [`server/python/app/enums.py`](diffhunk://#diff-ec8b4a3cae39b38486aba309266ca8cbcb2f5d7d4ff5b0b8b77d6c0ccd1ec0e7R46-R51): Introduced `MediaFormat` enum to specify audio formats.
* [`server/python/app/models.py`](diffhunk://#diff-c19ce1831bfa7646e4af91da45df863a1e45a9ee2afb0d0101634f7aa5a96b36R38): Added `audio_buffer` attribute to the `ClientSession` class to store audio data.

### WebSocket Server Updates:
* `server/python/app/websocket_server.py`: Enhanced the WebSocket server to handle and save audio data, including:
  * Importing `save_to_wav` from `audio.py`.
  * Handling connection probes and selecting appropriate media formats. [[1]](diffhunk://#diff-3440fbd7713d58aec69f700260474da1227684216cd0e40b01835b1c0db2d6d5R201-R239) [[2]](diffhunk://#diff-3440fbd7713d58aec69f700260474da1227684216cd0e40b01835b1c0db2d6d5R282-R313)
  * Saving audio data to WAV files upon session closure.
  * Initializing and appending to the audio buffer for each session.

### Logging Configuration:
* [`server/python/server.py`](diffhunk://#diff-58fbdd66ef74e0db16703aa2163be893e6cd0b9d6f8e93891ee00392c8b6564cR7-R12): Adjusted logging levels based on environment variables to differentiate between production and development environments. [[1]](diffhunk://#diff-58fbdd66ef74e0db16703aa2163be893e6cd0b9d6f8e93891ee00392c8b6564cR7-R12) [[2]](diffhunk://#diff-58fbdd66ef74e0db16703aa2163be893e6cd0b9d6f8e93891ee00392c8b6564cL16-L21)