### PR TITLE
[GH-workspace generated] Fix recognizing events broadcasting to Azure Event Hub

### DIFF
--- a/server/python/app/websocket_server.py
+++ b/server/python/app/websocket_server.py
@@ -509,15 +509,14 @@ class WebsocketServer:
             self.logger.info(f"[{session_id}] Recognizing {event.result.text}")
             self.logger.debug(f"[{session_id}] Recognizing JSON: {event.result.json}")
 
-            # TODO This doesn't work
-            loop = asyncio.get_running_loop()
+            # Ensure self.send_event is called asynchronously
             asyncio.run_coroutine_threadsafe(
                 self.send_event(
                     event=AzureGenesysEvent.PARTIAL_TRANSCRIPT,
                     session_id=session_id,
                     message={"transcript": event.result.text},
                 ),
-                loop,
+                self.get_event_loop(),
             )
 
         def recognized_cb(event: speechsdk.SpeechRecognitionEventArgs):
@@ -560,3 +559,7 @@ class WebsocketServer:
         speech_recognizer.stop_continuous_recognition_async().get()
 
         self.logger.info(f"[{session_id}] Stopped continuous recognition.")
+
+    def get_event_loop(self):
+        """Return the event loop."""
+        return asyncio.get_event_loop()

--- a/server/python/app/websocket_server.py
+++ b/server/python/app/websocket_server.py
@@ -460,6 +460,8 @@ class WebsocketServer:
             if properties:
                 event_data.properties.update(properties)
 
+            self.logger.debug("Sending event to Azure Event Hub.", event_data)
+
             event_data_batch.add(event_data)
             await self.producer_client.send_batch(event_data_batch)
 


### PR DESCRIPTION
Update `recognizing_cb` function to broadcast recognizing events to Azure Event Hub.

* **Recognizing Events Broadcasting**
  - Update `recognizing_cb` function to use `asyncio.run_coroutine_threadsafe` correctly.
  - Ensure `self.send_event` is called asynchronously in `recognizing_cb` function.
  - Add a new method `get_event_loop` to return the event loop.

